### PR TITLE
Fix compilation in C++11 standard

### DIFF
--- a/anitomy/keyword.h
+++ b/anitomy/keyword.h
@@ -20,6 +20,9 @@ namespace anitomy {
 struct TokenRange;
 
 struct KeywordOptions {
+  KeywordOptions() {}
+  KeywordOptions(bool identifiable, bool searchable, bool valid)
+      : identifiable(identifiable), searchable(searchable), valid(valid) {}
   bool identifiable = true;
   bool searchable = true;
   bool valid = true;

--- a/anitomy/token.h
+++ b/anitomy/token.h
@@ -42,6 +42,8 @@ enum TokenFlag {
 };
 
 struct TokenRange {
+  TokenRange() {}
+  TokenRange(size_t offset, size_t size) : offset(offset), size(size) {}
   size_t offset = 0;
   size_t size = 0;
 };


### PR DESCRIPTION
Under C++11 the TokenRange & KeywordOption structs require constructors due to the use of non-static data member initialisation. This restriction was lifted in the C++14 standard.