### PR TITLE
keyword: Add E-AC3 as AudioCodec keyword

### DIFF
--- a/include/anitomy/detail/keyword.hpp
+++ b/include/anitomy/detail/keyword.hpp
@@ -99,6 +99,7 @@ inline auto keywords = []() -> keyword_map_t {
       {"AC3",                  {AudioCodec, 0}},
       {"EAC3",                 {AudioCodec, 0}},
       {"E-AC-3",               {AudioCodec, 0}},
+      {"E-AC3",                {AudioCodec, 0}},
       {"FLAC",                 {AudioCodec, 0}},
       {"FLACX2",               {AudioCodec, 0}},
       {"FLACX3",               {AudioCodec, 0}},

--- a/test/data.json
+++ b/test/data.json
@@ -2831,5 +2831,25 @@
             "file_checksum": "32FD04E5",
             "file_extension": "mkv"
         }
+    },
+    {
+        "input": "[Kaleido-subs] Blue Archive the Animation - S01E07 - (WEB 1080p HEVC x265 10-bit E-AC3 2.0) [3B0015AF].mkv",
+        "mal_id": 54309,
+        "output": {
+            "release_group": "Kaleido-subs",
+            "title": "Blue Archive the Animation",
+            "season": "01",
+            "episode": "07",
+            "video_resolution": "1080p",
+            "video_term": [
+                "HEVC",
+                "x265",
+                "10-bit"
+            ],
+            "audio_term": "E-AC3",
+            "source": "WEB",
+            "file_checksum": "3B0015AF",
+            "file_extension": "mkv"
+        }
     }
 ]


### PR DESCRIPTION
Add E-AC3 as AudioCodec keyword which wasn't include in the Audio codec keyword
list.
Add test for E-AC3 audio codec because it was added as new keyword previously.