### PR TITLE
Add workaround so it can build with gcc/clang

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -8,38 +8,105 @@
   "configurePresets": [
     {
       "name": "ninja-multi",
+      "hidden": true,
       "displayName": "Ninja Multi-Config",
       "generator": "Ninja Multi-Config",
-      "binaryDir": "${sourceDir}/build/${presetName}",
+      "binaryDir": "${sourceDir}/build/${presetName}"
+    },
+    {
+      "name": "msvc",
       "cacheVariables": {
-        "CMAKE_CXX_COMPILER": "cl.exe"
-      }
+        "CMAKE_CXX_COMPILER": "cl"
+      },
+      "inherits": ["ninja-multi"]
+    },
+    {
+      "name": "gcc",
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "g++"
+      },
+      "inherits": ["ninja-multi"]
+    },
+    {
+      "name": "clang",
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "clang++"
+      },
+      "inherits": ["ninja-multi"]
     }
   ],
   "buildPresets": [
     {
-      "name": "ninja-debug",
-      "configurePreset": "ninja-multi",
+      "name": "msvc-debug",
+      "configurePreset": "msvc",
       "displayName": "Debug",
       "configuration": "Debug"
     },
     {
-      "name": "ninja-release",
-      "configurePreset": "ninja-multi",
+      "name": "msvc-release",
+      "configurePreset": "msvc",
+      "displayName": "Release",
+      "configuration": "Release"
+    },
+    {
+      "name": "gcc-debug",
+      "configurePreset": "gcc",
+      "displayName": "Debug",
+      "configuration": "Debug"
+    },
+    {
+      "name": "gcc-release",
+      "configurePreset": "gcc",
+      "displayName": "Release",
+      "configuration": "Release"
+    },
+    {
+      "name": "clang-debug",
+      "configurePreset": "clang",
+      "displayName": "Debug",
+      "configuration": "Debug"
+    },
+    {
+      "name": "clang-release",
+      "configurePreset": "clang",
       "displayName": "Release",
       "configuration": "Release"
     }
   ],
   "testPresets": [
     {
-      "name": "test-debug",
-      "configurePreset": "ninja-multi",
+      "name": "msvc-test-debug",
+      "configurePreset": "msvc",
       "displayName": "Debug",
       "configuration": "Debug"
     },
     {
-      "name": "test-release",
-      "configurePreset": "ninja-multi",
+      "name": "msvc-test-release",
+      "configurePreset": "msvc",
+      "displayName": "Release",
+      "configuration": "Release"
+    },
+    {
+      "name": "gcc-test-debug",
+      "configurePreset": "gcc",
+      "displayName": "Debug",
+      "configuration": "Debug"
+    },
+    {
+      "name": "gcc-test-release",
+      "configurePreset": "gcc",
+      "displayName": "Release",
+      "configuration": "Release"
+    },
+    {
+      "name": "clang-test-debug",
+      "configurePreset": "clang",
+      "displayName": "Debug",
+      "configuration": "Debug"
+    },
+    {
+      "name": "clang-test-release",
+      "configurePreset": "clang",
       "displayName": "Release",
       "configuration": "Release"
     }

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -5,3 +5,23 @@ target_sources(anitomy PUBLIC
         BASE_DIRS ${CMAKE_CURRENT_LIST_DIR}
         FILES anitomy.hpp
 )
+
+if(!MSVC)
+    if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
+        if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 16)
+            target_sources(anitomy PRIVATE
+                FILE_SET HEADERS
+                BASE_DIRS ${CMAKE_CURRENT_LIST_DIR}
+                FILES ranges.hpp
+            )
+        endif()
+    elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+        if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 22)
+            target_sources(anitomy PRIVATE
+                FILE_SET HEADERS
+                BASE_DIRS ${CMAKE_CURRENT_LIST_DIR}
+                FILES ranges.hpp
+            )
+        endif()
+    endif()
+endif()

--- a/include/anitomy/detail/json/parser.hpp
+++ b/include/anitomy/detail/json/parser.hpp
@@ -167,7 +167,7 @@ private:
     return error();
   }
 
-  [[nodiscard]] inline expected_t<nullptr_t> parse_null() noexcept {
+  [[nodiscard]] inline expected_t<std::nullptr_t> parse_null() noexcept {
     if (skip_literal("null")) return nullptr;
     return error();
   }

--- a/include/anitomy/detail/json/serializer.hpp
+++ b/include/anitomy/detail/json/serializer.hpp
@@ -27,25 +27,25 @@ public:
 private:
   inline void serialize_value(Value& value, std::string& output) noexcept {
     switch (value.kind()) {
-      case Value::Object:
+      case Value::Kind::Object:
         serialize_object(value.as_object(), output);
         break;
-      case Value::Array:
+      case Value::Kind::Array:
         serialize_array(value.as_array(), output);
         break;
-      case Value::String:
+      case Value::Kind::String:
         serialize_string(value.as_string(), output);
         break;
-      case Value::Integer:
+      case Value::Kind::Integer:
         serialize_integer(value.as_integer(), output);
         break;
-      case Value::Float:
+      case Value::Kind::Float:
         serialize_float(value.as_float(), output);
         break;
-      case Value::Boolean:
+      case Value::Kind::Boolean:
         serialize_boolean(value.as_bool(), output);
         break;
-      case Value::Null:
+      case Value::Kind::Null:
         serialize_null(output);
         break;
     }

--- a/include/anitomy/detail/json/value.hpp
+++ b/include/anitomy/detail/json/value.hpp
@@ -15,7 +15,7 @@ public:
   using array_t = std::vector<Value>;
   using value_t = std::variant<object_t, array_t, string_t, int, float, bool, std::nullptr_t>;
 
-  enum Kind : size_t {
+  enum class Kind : size_t {
     Object,
     Array,
     String,
@@ -94,7 +94,7 @@ public:
 
 private:
   [[nodiscard]] inline bool holds(const Kind kind) const noexcept {
-    return value_.index() == kind;
+    return value_.index() == static_cast<size_t>(kind);
   }
 
   value_t value_;

--- a/include/anitomy/detail/json/value.hpp
+++ b/include/anitomy/detail/json/value.hpp
@@ -13,7 +13,7 @@ public:
   using string_t = std::string;
   using object_t = Object<string_t, Value>;
   using array_t = std::vector<Value>;
-  using value_t = std::variant<object_t, array_t, string_t, int, float, bool, nullptr_t>;
+  using value_t = std::variant<object_t, array_t, string_t, int, float, bool, std::nullptr_t>;
 
   enum Kind : size_t {
     Object,

--- a/include/anitomy/detail/tokenizer.hpp
+++ b/include/anitomy/detail/tokenizer.hpp
@@ -8,6 +8,10 @@
 #include <utility>
 #include <vector>
 
+#if __cplusplus < 202106L || ! defined __cpp_lib_ranges_starts_ends_with
+#include "ranges.hpp"
+#endif
+
 #include <anitomy/detail/bracket.hpp>
 #include <anitomy/detail/delimiter.hpp>
 #include <anitomy/detail/keyword.hpp>

--- a/include/anitomy/detail/util.hpp
+++ b/include/anitomy/detail/util.hpp
@@ -5,6 +5,7 @@
 #include <fstream>
 #include <string_view>
 #include <unordered_map>
+#include <vector>
 
 namespace anitomy::detail {
 

--- a/include/ranges.hpp
+++ b/include/ranges.hpp
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <algorithm>
+#include <ranges>
+#include <utility>
+
+// This file contains `std::ranges::starts_with` and `std::ranges::ends_with`
+// taken from the "Possible implementation" code found on cppreference.com.
+// https://en.cppreference.com/w/cpp/algorithm/ranges/starts_with.html
+// https://en.cppreference.com/w/cpp/algorithm/ranges/ends_with.html
+
+namespace std::ranges {
+struct starts_with_fn {
+  template <std::input_iterator I1, std::sentinel_for<I1> S1, std::input_iterator I2,
+            std::sentinel_for<I2> S2, class Pred = ranges::equal_to, class Proj1 = std::identity,
+            class Proj2 = std::identity>
+    requires std::indirectly_comparable<I1, I2, Pred, Proj1, Proj2>
+  constexpr bool operator()(I1 first1, S1 last1, I2 first2, S2 last2, Pred pred = {},
+                            Proj1 proj1 = {}, Proj2 proj2 = {}) const {
+    return ranges::mismatch(std::move(first1), last1, std::move(first2), last2, std::move(pred),
+                            std::move(proj1), std::move(proj2))
+               .in2 == last2;
+  }
+
+  template <ranges::input_range R1, ranges::input_range R2, class Pred = ranges::equal_to,
+            class Proj1 = std::identity, class Proj2 = std::identity>
+    requires std::indirectly_comparable<ranges::iterator_t<R1>, ranges::iterator_t<R2>, Pred, Proj1,
+                                        Proj2>
+  constexpr bool operator()(R1&& r1, R2&& r2, Pred pred = {}, Proj1 proj1 = {},
+                            Proj2 proj2 = {}) const {
+    return (*this)(ranges::begin(r1), ranges::end(r1), ranges::begin(r2), ranges::end(r2),
+                   std::move(pred), std::move(proj1), std::move(proj2));
+  }
+};
+
+inline constexpr starts_with_fn starts_with{};
+
+struct ends_with_fn {
+  template <std::input_iterator I1, std::sentinel_for<I1> S1, std::input_iterator I2,
+            std::sentinel_for<I2> S2, class Pred = ranges::equal_to, class Proj1 = std::identity,
+            class Proj2 = std::identity>
+    requires(std::forward_iterator<I1> || std::sized_sentinel_for<S1, I1>) &&
+            (std::forward_iterator<I2> || std::sized_sentinel_for<S2, I2>) &&
+            std::indirectly_comparable<I1, I2, Pred, Proj1, Proj2>
+  constexpr bool operator()(I1 first1, S1 last1, I2 first2, S2 last2, Pred pred = {},
+                            Proj1 proj1 = {}, Proj2 proj2 = {}) const {
+    const auto n1 = ranges::distance(first1, last1);
+    const auto n2 = ranges::distance(first2, last2);
+    if (n1 < n2) return false;
+    ranges::advance(first1, n1 - n2);
+    return ranges::equal(std::move(first1), last1, std::move(first2), last2, pred, proj1, proj2);
+  }
+
+  template <ranges::input_range R1, ranges::input_range R2, class Pred = ranges::equal_to,
+            class Proj1 = std::identity, class Proj2 = std::identity>
+    requires(ranges::forward_range<R1> || ranges::sized_range<R1>) &&
+            (ranges::forward_range<R2> || ranges::sized_range<R2>) &&
+            std::indirectly_comparable<ranges::iterator_t<R1>, ranges::iterator_t<R2>, Pred, Proj1,
+                                       Proj2>
+  constexpr bool operator()(R1&& r1, R2&& r2, Pred pred = {}, Proj1 proj1 = {},
+                            Proj2 proj2 = {}) const {
+    const auto n1 = ranges::distance(r1);
+    const auto n2 = ranges::distance(r2);
+    if (n1 < n2) return false;
+    return ranges::equal(views::drop(ranges::ref_view(r1), n1 - static_cast<decltype(n1)>(n2)), r2,
+                         pred, proj1, proj2);
+  }
+};
+
+inline constexpr ends_with_fn ends_with{};
+}  // namespace std::ranges

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,4 +22,7 @@ else()
 		-Wall
 		-Wextra
 	)
+	if(MINGW)
+		target_link_libraries(anitomy-cli stdc++exp)
+	endif()
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,4 +22,7 @@ else()
 		-Wall
 		-Wextra
 	)
+	if(MINGW)
+		target_link_libraries(anitomy-tests stdc++exp)
+	endif()
 endif()


### PR DESCRIPTION
Added check for `__cpp_lib_ranges_starts_ends_with` that if not defined includes a `ranges.hpp` that uses the "Possible implementation" code from cppreference.com to provide the missing functions.

```cpp
#if __cplusplus < 202106L || ! defined __cpp_lib_ranges_starts_ends_with
#include "ranges.hpp"
#endif
```