### PR TITLE
Added colon as a delimiter

### DIFF
--- a/include/anitomy/detail/delimiter.hpp
+++ b/include/anitomy/detail/delimiter.hpp
@@ -40,6 +40,7 @@ namespace anitomy::detail {
     case U'~':  // used for episode ranges
     case U'+':  // used in torrent titles
     case U'|':  // used in torrent titles, reserved in Windows
+    case U':':
       return true;
     default:
       return is_space(ch) || is_dash(ch);

--- a/include/anitomy/detail/delimiter.hpp
+++ b/include/anitomy/detail/delimiter.hpp
@@ -40,7 +40,7 @@ namespace anitomy::detail {
     case U'~':  // used for episode ranges
     case U'+':  // used in torrent titles
     case U'|':  // used in torrent titles, reserved in Windows
-    case U':':
+    case U':':  // used to present the episode title (e.g. `E01:Some Title`)
       return true;
     default:
       return is_space(ch) || is_dash(ch);


### PR DESCRIPTION
colon was missing from the delimiter list which caused issues tokenizing and in return paring the actual file name
This is a direct fix to the issue: [#37](https://github.com/erengy/anitomy/issues/37)

Before:
title Sasameki Koto E02: Cute People
file_extension mkv

After:
title           Sasameki Koto
episode         02
episode_title   Cute People
file_extension  mkv

